### PR TITLE
RFC 5116 compliance: Link security analysis (AEGIS paper)

### DIFF
--- a/draft-denis-aegis-aead.md
+++ b/draft-denis-aegis-aead.md
@@ -689,6 +689,8 @@ AEGIS-256 offers 256-bit message security against plaintext and state recovery. 
 
 The security of AEGIS against timing attacks is limited by the implementation of the underlying `AESRound()` function. Failure to implement `AESRound()` in a fashion safe against side-channel attacks, such as differential power analysis or timing attacks, may likely lead to leaking secret key material or state information. The exact mitigations required for side-channel attacks also depend on the threat model in question.
 
+A security analysis of AEGIS can be found in Chapter 4 of {{AEGIS}}.
+
 # IANA Considerations
 
 IANA is requested to assign entries for `AEAD_AEGIS128L` and `AEAD_AEGIS256` in the AEAD Registry with this document as reference.


### PR DESCRIPTION
RFC 5116 § 4: "Each AEAD algorithm specification SHOULD provide a reference to a detailed security analysis."

The AEGIS paper contains an analysis in chapter 4.

`{{AEGIS, Chapter 4}}` doesn't work since section-wise reference only seems to work for RFCs and even then it'd have to be "Section", but it's called "Chapter" in the paper.

---

I'm not entirely convinced that it's prim and proper to link an analysis performed by the designers of the algorithm. On the other hand, there's no other comprehensive paper I could find. The ones on IACR are only individual attacks on AEGIS.