### PR TITLE
AEGIS-128L: allow up to 2^48 messages per key

### DIFF
--- a/draft-denis-aegis-aead.md
+++ b/draft-denis-aegis-aead.md
@@ -747,7 +747,7 @@ Every key MUST be randomly chosen from a uniform distribution.
 
 The nonce MAY be public or predictable. It can be a counter, the output of a permutation, or a generator with a long period.
 
-With AEGIS-128L, random nonces can safely encrypt up to 2<sup>32</sup> messages using the same key with negligible collision probability.
+With AEGIS-128L, random nonces can safely encrypt up to 2<sup>48</sup> messages using the same key with negligible collision probability.
 
 With AEGIS-256, random nonces can be used with no practical limits.
 


### PR DESCRIPTION
As pointed out by Daniel, the 2^32 bound was too conservative.

With a 128 bit nonce, encrypting up 2^48 messages still gives collision probability smaller than 2^-32, which matches NIST standards.