### PR TITLE
Properly truncate the ciphertext - Address @soatok's feedback

### DIFF
--- a/draft-denis-aegis-aead.md
+++ b/draft-denis-aegis-aead.md
@@ -202,7 +202,7 @@ for xi in msg_blocks:
     ct = ct || Enc(xi)
 
 tag = Finalize(|ad|, |msg|)
-msg = Truncate(msg, |ct|)
+ct = Truncate(ct, |msg|)
 ~~~
 
 ## Authenticated Decryption
@@ -492,6 +492,7 @@ for xi in msg_blocks:
     ct = ct || Enc(xi)
 
 tag = Finalize(|ad|, |msg|)
+ct = Truncate(ct, |msg|)
 ~~~
 
 ## Authenticated Decryption


### PR DESCRIPTION
Address @soatok 's  feedback on the CFRG list:

- In the AEGIS128L Encrypt() function, `msg` and `ct` were swapped.
- In the AEGIS256 Encrypt() function, the truncation step was forgotten.

