### PR TITLE
Add Security subsections

### DIFF
--- a/draft-denis-aegis-aead.md
+++ b/draft-denis-aegis-aead.md
@@ -219,8 +219,7 @@ Decrypt(ct, tag, ad, key, nonce)
 The `Decrypt` function decrypts a ciphertext, verifies that the authentication tag is correct, and returns the message on success or an error if tag verification failed.
 
 Security:
-- If tag verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output.
-- If the decryption process is implemented such that a buffer is supplied by the caller and said buffer is modified to contain partial decrypted data, the buffer MUST fully overwrite the supplied buffer with non-secret data, such as setting it to an all-zero value.
+- If tag verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output. The decrypted message MUST be overwritten with zeros.
 - The comparison of the input `tag` with the `expected_tag` SHOULD be done in constant time.
 
 Inputs:
@@ -258,6 +257,7 @@ if cn is not empty:
 expected_tag = Finalize(|ad|, |msg|)
 
 if CtEq(tag, expected_tag) is False:
+    erase msg
     return "verification failed" error
 else:
     return msg
@@ -531,8 +531,7 @@ Decrypt(ct, tag, ad, key, nonce)
 The `Decrypt` function decrypts a ciphertext, verifies that the authentication tag is correct, and returns the message on success or an error if tag verification failed.
 
 Security:
-- If tag verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output.
-- If the decryption process is implemented such that a buffer is supplied by the caller and said buffer is modified to contain partial decrypted data, the buffer MUST fully overwrite the supplied buffer with non-secret data, such as setting it to an all-zero value.
+- If tag verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output. The decrypted message MUST be overwritten with zeros.
 - The comparison of the input `tag` with the `expected_tag` SHOULD be done in constant time.
 
 Inputs:
@@ -570,6 +569,7 @@ if cn is not empty:
 expected_tag = Finalize(|ad|, |msg|)
 
 if CtEq(tag, expected_tag) is False:
+    erase msg
     return "verification failed" error
 else:
     return msg

--- a/draft-denis-aegis-aead.md
+++ b/draft-denis-aegis-aead.md
@@ -171,7 +171,11 @@ It is up to the application to create a structure in the associated data input i
 Encrypt(msg, ad, key, nonce)
 ~~~
 
-The `Encrypt` function encrypts a message and returns the ciphertext along with an authentication tag that verifies the authenticity of the message and associated data, if provided. The nonce MUST NOT be reused under any circumstances; doing so allows an attacker to recover the internal state.
+The `Encrypt` function encrypts a message and returns the ciphertext along with an authentication tag that verifies the authenticity of the message and associated data, if provided.
+
+Security:
+- The nonce MUST NOT be reused under any circumstances; doing so allows an attacker to recover the internal state.
+- The key MUST be randomly chosen from a uniform distribution.
 
 Inputs:
 
@@ -214,6 +218,11 @@ Decrypt(ct, tag, ad, key, nonce)
 
 The `Decrypt` function decrypts a ciphertext, verifies that the authentication tag is correct, and returns the message on success or an error if tag verification failed.
 
+Security:
+- If tag verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output.
+- If the decryption process is implemented such that a buffer is supplied by the caller and said buffer is modified to contain partial decrypted data, the buffer MUST fully overwrite the supplied buffer with non-secret data, such as setting it to an all-zero value.
+- The comparison of the input `tag` with the `expected_tag` SHOULD be done in constant time.
+
 Inputs:
 
 - `ct`: the ciphertext to be decrypted.
@@ -224,7 +233,7 @@ Inputs:
 
 Outputs:
 
-- either the decrypted message `msg`, or an error indicating that the authentication tag is invalid for the given inputs.
+- Either the decrypted message `msg`, or an error indicating that the authentication tag is invalid for the given inputs.
 
 Steps:
 
@@ -253,8 +262,6 @@ if CtEq(tag, expected_tag) is False:
 else:
     return msg
 ~~~
-
-The comparison of the input `tag` with the `expected_tag` SHOULD be done in constant time. If verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output. If the decryption process is implemented such that a buffer is supplied by the caller and said buffer is modified to contain partial decrypted data, the buffer MUST fully overwrite the supplied buffer with non-secret data, such as setting it to an all-zero value.
 
 ## The Init Function
 
@@ -476,7 +483,11 @@ It is up to the application to create a structure in the associated data input i
 Encrypt(msg, ad, key, nonce)
 ~~~
 
-The `Encrypt` function encrypts a message and returns the ciphertext along with an authentication tag that verifies the authenticity of the message and associated data, if provided. The nonce MUST NOT be reused under any circumstances; doing so allows an attacker to recover the internal state.
+The `Encrypt` function encrypts a message and returns the ciphertext along with an authentication tag that verifies the authenticity of the message and associated data, if provided.
+
+Security:
+- The nonce MUST NOT be reused under any circumstances; doing so allows an attacker to recover the internal state.
+- The key MUST be randomly chosen from a uniform distribution.
 
 Inputs:
 
@@ -519,6 +530,11 @@ Decrypt(ct, tag, ad, key, nonce)
 
 The `Decrypt` function decrypts a ciphertext, verifies that the authentication tag is correct, and returns the message on success or an error if tag verification failed.
 
+Security:
+- If tag verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output.
+- If the decryption process is implemented such that a buffer is supplied by the caller and said buffer is modified to contain partial decrypted data, the buffer MUST fully overwrite the supplied buffer with non-secret data, such as setting it to an all-zero value.
+- The comparison of the input `tag` with the `expected_tag` SHOULD be done in constant time.
+
 Inputs:
 
 - `ct`: the ciphertext to be decrypted.
@@ -529,7 +545,7 @@ Inputs:
 
 Outputs:
 
-- either the decrypted message `msg`, or an error indicating that the authentication tag is invalid for the given inputs.
+- Either the decrypted message `msg`, or an error indicating that the authentication tag is invalid for the given inputs.
 
 Steps:
 
@@ -558,8 +574,6 @@ if CtEq(tag, expected_tag) is False:
 else:
     return msg
 ~~~
-
-The comparison of the input `tag` with the `expected_tag` SHOULD be done in constant time. If verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output. If the decryption process is implemented such that a buffer is supplied by the caller and said buffer is modified to contain partial decrypted data, the buffer MUST fully overwrite the supplied buffer with non-secret data, such as setting it to an all-zero value.
 
 ## The Init Function
 
@@ -771,7 +785,7 @@ Under the assumption that the secret key is unknown to the attacker and the tag 
 
 Both algorithms MUST be used in a nonce-respecting setting: for a given `key`, a `nonce` MUST only be used once. Failure to do so would immediately reveal the bitwise difference between two messages.
 
-If verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output. As shown in the analysis of the (robustness of CAESAR candidates beyond their guarantees){{CRA18}}, even a partial leak of the plaintext without verification would facilitate chosen ciphertext attacks.
+If tag verification fails, the decrypted message and wrong message authentication tag MUST NOT be given as output. As shown in the analysis of the (robustness of CAESAR candidates beyond their guarantees){{CRA18}}, even a partial leak of the plaintext without verification would facilitate chosen ciphertext attacks.
 
 Every key MUST be randomly chosen from a uniform distribution.
 


### PR DESCRIPTION
Closes #38. Also, some minor rewording and grammar changes.

> the buffer MUST fully overwrite the supplied buffer with non-secret data

Is this a mistake?